### PR TITLE
Fix: Error negating boolean tensor during task=vrp

### DIFF
--- a/tasks/vrp.py
+++ b/tasks/vrp.py
@@ -84,8 +84,8 @@ class VehicleRoutingDataset(Dataset):
 
         if repeat_home.any():
             new_mask[repeat_home.nonzero(), 0] = 1.
-        if (1 - repeat_home).any():
-            new_mask[(1 - repeat_home).nonzero(), 0] = 0.
+        if (~repeat_home).any():
+            new_mask[(~repeat_home).nonzero(), 0] = 0.
 
         # ... unless we're waiting for all other samples in a minibatch to finish
         has_no_load = loads[:, 0].eq(0).float()


### PR DESCRIPTION
I encountered an error when trying to execute the VRP task. During updating of the mask a boolean tensor is negated which leads to an error. This can be fixed by altering the negation to use the tilde (~) operator.

Summary:
- negation using 1 - boolean tensor leads to an error
- use ~ to negate boolean tensor instead